### PR TITLE
fix: pass condition in recursive function

### DIFF
--- a/addons/anim_player_refactor/lib/editor_util.gd
+++ b/addons/anim_player_refactor/lib/editor_util.gd
@@ -26,7 +26,7 @@ static func find_editor_control_with_class(
 		if not child is Control:
 			continue
 			
-		var found = find_editor_control_with_class(child, p_class_name)
+		var found = find_editor_control_with_class(child, p_class_name, condition)
 		if found:
 			return found
 		


### PR DESCRIPTION
I was looking to do something similar to what you do in this addon, but I found that the "find_editor_control_with_class_function" has a bug. it doesn't pass the condition so it is always true and returns the first found node.